### PR TITLE
Add angular2-es-seed to Babel Seed Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ TypeScript is a typed superset of JavaScript that compiles to plain JavaScript.
 * [babel-angular2-app](https://github.com/shuhei/babel-angular2-app) A skeleton Angular 2 app built with [Babel](https://babeljs.io/) and [Browserify](http://browserify.org/).
 * [angular2-fullstack-starter](https://github.com/jgodi/angular2-fullstack-starter) A full stack skeleton Angular 2 app built with Webpack/Babel.
 * [angular2-es6-starter](https://github.com/blacksonic/angular2-es6-starter) A skeleton Angular 2 ES6 application built with Babel, Webpack, Gulp.
+* [angular2-es-seed](https://github.com/codewareio/angular2-es-seed) A complete, yet simple, starter for Angular 2 using ES2016.
 * [**{{** add_your_repo **}}**](https://github.com/angularclass/awesome-angular2/edit/gh-pages/README.md)
 
 #### Babel Demo, Samples, and Examples


### PR DESCRIPTION
Add [angular2-es-seed][1] to Babel Seed Projects.

ps: @gdi2290 if you are interested check it out, it is [heavily][2] inspired by [AngularClass/angular2-webpack-starter][3]. Maybe you will find a few solutions, you might like to implement into the TS counterpart project. I surely took a lot from angular2-webpack-starter, furthermore i keep scanning the commits and implement bugfixes constantly. 

[1]: https://github.com/codewareio/angular2-es-seed
[2]: https://github.com/codewareio/angular2-es-seed#angularclass
[3]: https://github.com/AngularClass/angular2-webpack-starter