### PR TITLE
fix(style-guide): remove deprecated style guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,7 @@ Http is available as an injectable class, with methods to perform http requests.
 
 #### Style Guides
 
-* [Community-driven style guide for Angular 2 application development](https://github.com/mgechev/angular2-style-guide)
-* [John Papa - Angular 2 style guide](https://github.com/johnpapa/angular-styleguide/tree/master/a2)
+* [Official Angular 2 Style guide](https://angular.io/styleguide)
 
 #### Angular Connect
 * [Keynote – Brad Green, Igor Minar and Jules Kremer](https://www.youtube.com/watch?v=UxjgUjVpe24)


### PR DESCRIPTION
[Remove](https://github.com/mgechev/angular2-style-guide) [deprecated](https://github.com/johnpapa/angular-styleguide/tree/master/a2#relocating-the-angular-2-style-guide) style guides and adds link to the official Angular 2 style guide.