### PR TITLE
Add Code School's Angular 2 course links

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Http is available as an injectable class, with methods to perform http requests.
 * [Pluralsight - Angular 2: Getting Started](https://www.pluralsight.com/courses/angular-2-getting-started)
 * [Channel9 - The Future of TypeScript: ECMAScript 6, Async/Await and Richer Libraries](https://channel9.msdn.com/Events/Build/2015/3-644)
 * [Channel9 - Creating Cross-Platform Apps with Angular 2](https://channel9.msdn.com/Events/Build/2016/T627)
+* [Code School - Accelerating Through Angular 2](https://www.codeschool.com/courses/accelerating-through-angular-2/)
 
 #### Style Guides
 

--- a/index.html
+++ b/index.html
@@ -252,6 +252,7 @@
 <ul>
 <li><a href="https://egghead.io/technologies/angular2">Egghead.io - Angular 2</a></li>
 <li><a href="https://www.udemy.com/introduction-to-angular2/">udemy - Introduction to Angular 2</a></li>
+<li><a href="https://www.codeschool.com/courses/accelerating-through-angular-2/">Code School - Accelerating Through Angular 2</a></li>
 </ul>
 
 <h4>


### PR DESCRIPTION
This adds a link to Code School's _Accelerating Through Angular 2_ course to the `README.md` and the `index.html` files.

Let us know if any changes are needed! 😄 